### PR TITLE
Multiple source updates and misc change

### DIFF
--- a/assets/website_configs/animekaizoku.json
+++ b/assets/website_configs/animekaizoku.json
@@ -4,7 +4,7 @@
         "anime"
     ],
     "search": {
-        "url": "https://animekaizoku.com/?s=",
+        "url": "https://animekaizoku.xyz/?s=",
         "spaceReplacement": "+",
         "itemKeys": {
             "root": "li.post-item",

--- a/assets/website_configs/apkmb.json
+++ b/assets/website_configs/apkmb.json
@@ -10,13 +10,13 @@
         "url": "https://apkmb.com/?s=",
         "spaceReplacement": "+",
         "itemKeys": {
-            "root": ".bloque-app",
+            "root": ".bav",
             "name": ".title",
             "thumbnail": {
                 "key": ".bloque-imagen img",
-                "attribute": "data-src"
+                "attribute": "src"
             },
-            "link": "a"
+            "link": ".bav a"
         }
     }
 }

--- a/assets/website_configs/audiobookbay.json
+++ b/assets/website_configs/audiobookbay.json
@@ -4,7 +4,7 @@
         "audio_books"
     ],
     "search": {
-        "url": "https://audiobookbay.li/?s=",
+        "url": "https://audiobookbay.is/?s=",
         "spaceReplacement": "+",
         "itemKeys": {
             "root": ".post",

--- a/assets/website_configs/audiobooksbee.json
+++ b/assets/website_configs/audiobooksbee.json
@@ -11,7 +11,7 @@
             "name": "h3 a",
             "thumbnail": {
                 "key": "figure img",
-                "attribute": "data-src"
+                "attribute": "src"
             },
             "link": "h3 a",
             "metadata": {

--- a/assets/website_configs/dodi-repacks.json
+++ b/assets/website_configs/dodi-repacks.json
@@ -7,10 +7,10 @@
         "url": "https://dodi-repacks.site/?s=",
         "spaceReplacement": "+",
         "itemKeys": {
-            "root": "article.post",
+            "root": ".post",
             "name": ".entry-title a",
             "thumbnail": {
-                "key": ".entry-content p:nth-of-type(1) img",
+                "key": ".entry-content img",
                 "attribute": "src",
                 "onItemPage": "true"
             },

--- a/assets/website_configs/emugames.json
+++ b/assets/website_configs/emugames.json
@@ -7,15 +7,15 @@
         "url": "https://www.emugames.net/search/?query=",
         "spaceReplacement": "+",
         "itemKeys": {
-            "root": ".site-list li",
-            "name": ".site-box-title",
+            "root": ".emugames-post",
+            "name": ".emugames-post-title",
             "thumbnail": {
-                "key": "picture img",
+                "key": ".emugames-post picture img",
                 "attribute": "src"
             },
-            "link": "a.site-box",
+            "link": ".emugames-post",
             "metadata": {
-                "console": ".site-box-badge"
+                "console": ".emugames-post-badge"
             }
         }
     }

--- a/assets/website_configs/gload.json
+++ b/assets/website_configs/gload.json
@@ -9,16 +9,16 @@
         "spaceReplacement": "+",
         "itemKeys": {
             "root": "article.uk-article",
-            "name": ".uk-article-title",
+            "name": ".gamemainansichttitel",
             "thumbnail": {
-                "key": "img.maincover2",
+                "key": ".titelcontentcover",
                 "attribute": "src"
             },
-            "link": "a",
+            "link": ".titelcontenta",
             "metadata": {
-                "language": "li:nth-of-type(3)",
-                "category": "li:nth-of-type(4)",
-                "size": "li:nth-of-type(5)"
+                "language": "li:nth-of-type(2)",
+                "category": "li:nth-child(1)",
+                "size": "li:nth-of-type(4)"
             }
         }
     }

--- a/assets/website_configs/gog-games.json
+++ b/assets/website_configs/gog-games.json
@@ -10,13 +10,13 @@
         "url": "https://gog-games.to/search/",
         "spaceReplacement": " ",
         "itemKeys": {
-            "root": "a.block",
-            "name": "span.title",
+            "root": ".block",
+            "name": ".title",
             "thumbnail": {
                 "key": ".image img",
                 "attribute": "src"
             },
-            "link": "a"
+            "link": ".block"
         }
     }
 }

--- a/assets/website_configs/rarefilmm.json
+++ b/assets/website_configs/rarefilmm.json
@@ -13,7 +13,7 @@
             "name": ".excerpt-title a",
             "thumbnail": {
                 "key": ".featured-image",
-                "attribute": "background-image"
+                "attribute": "style"
             },
             "link": ".excerpt-title a"
         }

--- a/assets/website_configs/romulation.json
+++ b/assets/website_configs/romulation.json
@@ -30,7 +30,8 @@
             "name": "a",
             "thumbnail": {
                 "key": "",
-                "attribute": "src"
+                "attribute": "src",
+                "onItemPage": "true"
             },
             "link": "a"
         }

--- a/assets/website_configs/softarchive.json
+++ b/assets/website_configs/softarchive.json
@@ -10,7 +10,7 @@
         "music"
     ],
     "search": {
-        "url": "https://sanet.si/search/?q=",
+        "url": "https://softarchive.is/search/?q=",
         "spaceReplacement": "+",
         "categorySpecificAttributes": {
             "name": "category",

--- a/assets/website_configs/softarchive.json
+++ b/assets/website_configs/softarchive.json
@@ -10,7 +10,7 @@
         "music"
     ],
     "search": {
-        "url": "https://sanet.st/search/?q=",
+        "url": "https://sanet.si/search/?q=",
         "spaceReplacement": "+",
         "categorySpecificAttributes": {
             "name": "category",

--- a/assets/website_configs/zoro.json
+++ b/assets/website_configs/zoro.json
@@ -4,7 +4,7 @@
         "anime"
     ],
     "search": {
-        "url": "https://zorohd.to/search?keyword=",
+        "url": "https://zorox.to/filter?keyword=",
         "spaceReplacement": "+",
         "itemKeys": {
             "root": ".flw-item",

--- a/htmlParsers/scrapePlainHtml.go
+++ b/htmlParsers/scrapePlainHtml.go
@@ -5,6 +5,7 @@ import (
 	"hatt/configuration"
 	"hatt/helpers"
 	"hatt/variables"
+	"regexp"
 	"strings"
 	"time"
 
@@ -34,6 +35,10 @@ func ScrapePlainHtml(config configuration.Config) []variables.Item {
 		var thumbnailLink string
 		if itemKeys.Thumbnail.Key == "root" {
 			thumbnailLink = h.Attr(itemKeys.Thumbnail.Attribute)
+		} else if itemKeys.Thumbnail.Attribute == "style" {
+			urlRegex := regexp.MustCompile(`url\(([^)]+)\)`)
+			style := h.ChildAttr(itemKeys.Thumbnail.Key, itemKeys.Thumbnail.Attribute)
+			thumbnailLink = urlRegex.FindStringSubmatch(style)[1]
 		} else {
 			thumbnailLink = h.ChildAttr(itemKeys.Thumbnail.Key, itemKeys.Thumbnail.Attribute)
 		}

--- a/htmlParsers/scrapePlainHtml.go
+++ b/htmlParsers/scrapePlainHtml.go
@@ -5,8 +5,8 @@ import (
 	"hatt/configuration"
 	"hatt/helpers"
 	"hatt/variables"
+	"net/url"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/gocolly/colly"
@@ -83,7 +83,7 @@ func ScrapePlainHtml(config configuration.Config) []variables.Item {
 	// 	fmt.Println(r)
 	// })
 
-	// c.OnError(func(r *colly.Response, err error) { fmt.Println(r, err) })
+	c.OnError(func(r *colly.Response, err error) { fmt.Println(r.StatusCode, err, r.Request.URL) })
 	c.SetRequestTimeout(30 * time.Second)
 	c.OnRequest(func(r *colly.Request) {
 		// maybe set this value according to the user's locale ?
@@ -98,7 +98,7 @@ func ScrapePlainHtml(config configuration.Config) []variables.Item {
 		formData[config.Search.PostFields.Input] = variables.CURRENT_INPUT
 		c.Post(config.Search.Url, formData)
 	} else {
-		formattedInput := config.Search.Url + strings.ReplaceAll(variables.CURRENT_INPUT, " ", config.Search.SpaceReplacement)
+		formattedInput := config.Search.Url + url.QueryEscape(variables.CURRENT_INPUT)
 		// some websites support multiple categories, to avoid irrelevant results, only search in relevant categories
 		if config.Search.CategorySpecificAttributes.Name != "" {
 			for category, value := range config.Search.CategorySpecificAttributes.Values {

--- a/htmlParsers/scrapePlainHtml.go
+++ b/htmlParsers/scrapePlainHtml.go
@@ -83,7 +83,7 @@ func ScrapePlainHtml(config configuration.Config) []variables.Item {
 	// 	fmt.Println(r)
 	// })
 
-	c.OnError(func(r *colly.Response, err error) { fmt.Println(r.StatusCode, err, r.Request.URL) })
+	// c.OnError(func(r *colly.Response, err error) { fmt.Println(r.StatusCode, err, r.Request.URL) })
 	c.SetRequestTimeout(30 * time.Second)
 	c.OnRequest(func(r *colly.Request) {
 		// maybe set this value according to the user's locale ?


### PR DESCRIPTION
So this is honestly a bigger pull than I normally like. But the changes are all fairly simple:
Updated many of the JSON sources fixing many mistakes ranging from bad URLs, Thumbnails not being selected.

Minor schema change as I replaced spaceReplacement key need by encoding the query the user provides using net/url QueryEscape. So all JSON files that use scrapePlainHTML can no longer specify spaceReplacement and it will work.

Finally my notes on various sources:

```
Broken: 
Oceanopdf - scraping blocked (403 forbidden)
nsw2u - javascript search
Game-2u - js search
dodi-repacks - js search
gog-games - js search
apkmb - js 
Forcoder - js

udemy24 - API (didnt debug)
soundcloud - API (didnt debug)
Magazinerack - API (didnt debug)

Fixed:
softarchive - updated website
Rarefilmm - thumbnails
Zoro - update site
Animekaizoku - OG site gone, new site xyz
Emugames - fixed element info
theaudiobookbay - update website

Sorta Fixed:
Gload - metadata repeats, unsure of good solution

Website is down, source doesn't work:
Trantor
slavart - down

Website has been intentionally shutdown:
Openloadmov - shutdown
Nesgm - shutdown
```