### PR TITLE
implemented onItemPage added scrapeItemPageHTML

### DIFF
--- a/assets/website_configs/animetosho.json
+++ b/assets/website_configs/animetosho.json
@@ -9,8 +9,9 @@
             "root": ".home_list_entry",
             "name": ".link a",
             "thumbnail": {
-                "key": "none",
-                "attribute": ""
+                "key": ".screenthumb img",
+                "attribute": "src",
+                "onItemPage": true
             },
             "link": ".link a",
             "metadata": {

--- a/assets/website_configs/ddlbase.json
+++ b/assets/website_configs/ddlbase.json
@@ -10,10 +10,11 @@
             "root": ".searchResult",
             "name": ".title a",
             "thumbnail": {
-                "key": "a.thumb",
-                "attribute": "data-thumbnailurl"
+                "key": ".messageText img",
+                "attribute": "src",
+                "onItemPage": true
             },
-            "link": "a.thumb",
+            "link": ".title a",
             "metadata": {
                 "host": ".title span.prefix",
                 "forum": ".meta a:nth-of-type(2)",

--- a/assets/website_configs/dodi-repacks.json
+++ b/assets/website_configs/dodi-repacks.json
@@ -11,7 +11,7 @@
             "thumbnail": {
                 "key": ".entry-content img",
                 "attribute": "src",
-                "onItemPage": "true"
+                "onItemPage": true
             },
             "link": ".entry-title a",
             "metadata": {}

--- a/assets/website_configs/fitgirl-repacks.json
+++ b/assets/website_configs/fitgirl-repacks.json
@@ -11,7 +11,7 @@
             "thumbnail": {
                 "key": ".entry-content p:nth-of-type(1) img",
                 "attribute": "src",
-                "onItemPage": "true"
+                "onItemPage": true
             },
             "link": ".entry-title a",
             "metadata": {}

--- a/assets/website_configs/hdaudiobooks.json
+++ b/assets/website_configs/hdaudiobooks.json
@@ -4,14 +4,14 @@
         "audio_books"
     ],
     "search": {
-        "url": "https://hdaudiobooks.com//?s=",
+        "url": "https://hdaudiobooks.com/?s=",
         "itemKeys": {
             "root": ".post",
             "name": "a",
             "thumbnail": {
-                "key": "figure img",
-                "attribute": "src",
-                "onItemPage": "true"
+                "key": ".frontImage",
+                "attribute": "data-lazy-src",
+                "onItemPage": true
             },
             "link": "a"
         }

--- a/assets/website_configs/romulation.json
+++ b/assets/website_configs/romulation.json
@@ -28,9 +28,10 @@
             "root": "tbody tr:not(:first-child)",
             "name": "a",
             "thumbnail": {
-                "key": "",
+                "key": ".owl-carousel img",
                 "attribute": "src",
-                "onItemPage": "true"
+                "onItemPage": true,
+                "appendToSiteUrl": true
             },
             "link": "a"
         }

--- a/assets/website_configs/softarchive.json
+++ b/assets/website_configs/softarchive.json
@@ -27,8 +27,9 @@
             "root": "tr.filerow",
             "name": ".cellMainLink i",
             "thumbnail": {
-                "key": "root",
-                "attribute": "data-poster_url"
+                "key": ".mfp-image",
+                "attribute": "href",
+                "onItemPage": true
             },
             "link": ".cellMainLink",
             "metadata": {

--- a/assets/website_configs/vimm.json
+++ b/assets/website_configs/vimm.json
@@ -36,7 +36,9 @@
             "name": "td:nth-of-type(2) a",
             "thumbnail": {
                 "key": ".innerMain a img",
-                "attribute": "src"
+                "attribute": "src",
+                "onItemPage": true,
+                "appendToSiteUrl": true
             },
             "link": "td:nth-of-type(2) a"
         }

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -41,8 +41,7 @@ type Thumbnail struct {
 	Key             string `json:"key"`
 	Attribute       string `json:"attribute"`
 	AppendToSiteUrl bool   `json:"appendToSiteUrl"`
-	// not handled yet in the code, but it means that the thumbnail is on the item's page
-	OnItemPage bool `json:"onItemPage"`
+	OnItemPage      bool   `json:"onItemPage"`
 }
 
 type PostFields struct {

--- a/htmlParsers/scrapeItemPageHtml.go
+++ b/htmlParsers/scrapeItemPageHtml.go
@@ -1,0 +1,46 @@
+package htmlParsers
+
+import (
+	"hatt/configuration"
+	"regexp"
+	"time"
+
+	"github.com/gocolly/colly"
+)
+
+func ScrapeItemPageHtml(config configuration.Config, url string) string {
+	var thumbnailLink string
+	c := colly.NewCollector()
+	c.UserAgent = "Mozilla/5.0 (Windows NT 10.0; rv:109.0) Gecko/20100101 Firefox/109.0"
+	itemKeys := config.Search.ItemKeys
+
+	// c.OnHTML("body", func(h *colly.HTMLElement) {
+	// 	fmt.Println(h)
+	// })
+
+	c.OnHTML(itemKeys.Thumbnail.Key, func(h *colly.HTMLElement) {
+		if thumbnailLink == "" {
+			if itemKeys.Thumbnail.Attribute == "style" {
+				urlRegex := regexp.MustCompile(`url\(([^)]+)\)`)
+				style := h.Attr(itemKeys.Thumbnail.Attribute)
+				thumbnailLink = urlRegex.FindStringSubmatch(style)[1]
+			} else {
+				thumbnailLink = h.Attr(itemKeys.Thumbnail.Attribute)
+			}
+
+			if itemKeys.Thumbnail.AppendToSiteUrl {
+				thumbnailLink = h.Request.AbsoluteURL(thumbnailLink)
+			}
+		}
+	})
+
+	// c.OnError(func(r *colly.Response, err error) { fmt.Println(r.StatusCode, err, r.Request.URL) })
+	c.SetRequestTimeout(30 * time.Second)
+	c.OnRequest(func(r *colly.Request) {
+		// maybe set this value according to the user's locale ?
+		r.Headers.Set("Accept-Language", "en")
+	})
+	c.Visit(url)
+
+	return thumbnailLink
+}

--- a/htmlParsers/scrapePlainHtml.go
+++ b/htmlParsers/scrapePlainHtml.go
@@ -33,19 +33,24 @@ func ScrapePlainHtml(config configuration.Config) []variables.Item {
 		}
 
 		var thumbnailLink string
-		if itemKeys.Thumbnail.Key == "root" {
-			thumbnailLink = h.Attr(itemKeys.Thumbnail.Attribute)
-		} else if itemKeys.Thumbnail.Attribute == "style" {
-			urlRegex := regexp.MustCompile(`url\(([^)]+)\)`)
-			style := h.ChildAttr(itemKeys.Thumbnail.Key, itemKeys.Thumbnail.Attribute)
-			thumbnailLink = urlRegex.FindStringSubmatch(style)[1]
+
+		if itemKeys.Thumbnail.OnItemPage != true {
+			if itemKeys.Thumbnail.Key == "root" {
+				thumbnailLink = h.Attr(itemKeys.Thumbnail.Attribute)
+			} else if itemKeys.Thumbnail.Attribute == "style" {
+				urlRegex := regexp.MustCompile(`url\(([^)]+)\)`)
+				style := h.ChildAttr(itemKeys.Thumbnail.Key, itemKeys.Thumbnail.Attribute)
+				thumbnailLink = urlRegex.FindStringSubmatch(style)[1]
+			} else {
+				thumbnailLink = h.ChildAttr(itemKeys.Thumbnail.Key, itemKeys.Thumbnail.Attribute)
+			}
+			if itemKeys.Thumbnail.AppendToSiteUrl {
+				item.Thumbnail = h.Request.AbsoluteURL(thumbnailLink)
+			} else {
+				item.Thumbnail = thumbnailLink
+			}
 		} else {
-			thumbnailLink = h.ChildAttr(itemKeys.Thumbnail.Key, itemKeys.Thumbnail.Attribute)
-		}
-		if itemKeys.Thumbnail.AppendToSiteUrl {
-			item.Thumbnail = h.Request.AbsoluteURL(thumbnailLink)
-		} else {
-			item.Thumbnail = thumbnailLink
+			item.Thumbnail = ScrapeItemPageHtml(config, item.Link)
 		}
 
 		item.Metadata = map[string]string{}

--- a/specificScrapers/ddlbase.go
+++ b/specificScrapers/ddlbase.go
@@ -2,6 +2,7 @@ package specificScrapers
 
 import (
 	"hatt/assets"
+	"hatt/htmlParsers"
 	"hatt/variables"
 	"strings"
 
@@ -19,10 +20,10 @@ func (t T) Ddlbase() []variables.Item {
 	c.OnHTML(itemKeys.Root, func(h *colly.HTMLElement) {
 
 		item := variables.Item{
-			Name:      strings.ReplaceAll(h.ChildText(itemKeys.Name), ".", " "),
-			Thumbnail: h.ChildAttr(itemKeys.Thumbnail.Key, itemKeys.Thumbnail.Attribute),
-			Link:      h.Request.AbsoluteURL(h.ChildAttr(itemKeys.Link, "href")),
+			Name: strings.ReplaceAll(h.ChildText(itemKeys.Name), ".", " "),
+			Link: h.Request.AbsoluteURL(h.ChildAttr(itemKeys.Link, "href")),
 		}
+		item.Thumbnail = htmlParsers.ScrapeItemPageHtml(config, item.Link)
 
 		item.Metadata = map[string]string{
 			"host":        h.ChildText(itemKeys.Metadata["host"]),


### PR DESCRIPTION
Bigger PR, implemented the on item page scraping, at the moment this is only for Thumbnails, but would theoretically work for metadata too with a bit of work. Atm only implemented on plainHTML scrape and ddlbase specific scraper. Also corrected all instances of "onItemPage" keys being strings into bools.  

This does make more HTML requests so it is slower on processing some so not 100% sure if we want to do metadata this way be default. 