### PR TITLE
Add hyphenated URL encoding option

### DIFF
--- a/assets/website_configs/f2movies.json
+++ b/assets/website_configs/f2movies.json
@@ -1,19 +1,17 @@
 {
-    "name": "f2movies",
-    "categories": [
-        "movies",
-        "tv_shows"
-    ],
-    "search": {
-        "url": "https://www6.f2movies.to/search/",
-        "itemKeys": {
-            "root": ".flw-item",
-            "name": ".film-detail .film-name a",
-            "thumbnail": {
-                "key": ".film-poster-img",
-                "attribute": "data-src"
-            },
-            "link": ".film-detail .film-name a"
-        }
+  "name": "f2movies",
+  "categories": ["movies", "tv_shows"],
+  "search": {
+    "url": "https://www6.f2movies.to/search/",
+    "encoding": "hyphen",
+    "itemKeys": {
+      "root": ".flw-item",
+      "name": ".film-detail .film-name a",
+      "thumbnail": {
+        "key": ".film-poster-img",
+        "attribute": "data-src"
+      },
+      "link": ".film-detail .film-name a"
     }
+  }
 }

--- a/assets/website_configs/himovies.json
+++ b/assets/website_configs/himovies.json
@@ -1,19 +1,17 @@
 {
-    "name": "himovies",
-    "categories": [
-        "movies",
-        "tv_shows"
-    ],
-    "search": {
-        "url": "https://www5.himovies.to/search/",
-        "itemKeys": {
-            "root": ".flw-item",
-            "name": ".film-detail .film-name a",
-            "thumbnail": {
-                "key": ".film-poster-img",
-                "attribute": "data-src"
-            },
-            "link": ".film-detail .film-name a"
-        }
+  "name": "himovies",
+  "categories": ["movies", "tv_shows"],
+  "search": {
+    "url": "https://www5.himovies.to/search/",
+    "encoding": "hyphen",
+    "itemKeys": {
+      "root": ".flw-item",
+      "name": ".film-detail .film-name a",
+      "thumbnail": {
+        "key": ".film-poster-img",
+        "attribute": "data-src"
+      },
+      "link": ".film-detail .film-name a"
     }
+  }
 }

--- a/assets/website_configs/sflix.json
+++ b/assets/website_configs/sflix.json
@@ -1,20 +1,18 @@
 {
-    "name": "sflix",
-    "categories": [
-        "movies",
-        "tv_shows"
-    ],
-    "subcategories": [],
-    "search": {
-        "url": "https://sflix.to/search/",
-        "itemKeys": {
-            "root": ".flw-item",
-            "name": ".film-name a",
-            "thumbnail": {
-                "key": ".film-poster-img",
-                "attribute": "data-src"
-            },
-            "link": ".film-name a"
-        }
+  "name": "sflix",
+  "categories": ["movies", "tv_shows"],
+  "subcategories": [],
+  "search": {
+    "url": "https://sflix.to/search/",
+    "encoding": "hyphen",
+    "itemKeys": {
+      "root": ".flw-item",
+      "name": ".film-name a",
+      "thumbnail": {
+        "key": ".film-poster-img",
+        "attribute": "data-src"
+      },
+      "link": ".film-name a"
     }
+  }
 }

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -22,6 +22,7 @@ type Search struct {
 	Method                     string                     `json:"method"` // POST or GET
 	ItemKeys                   ItemKeys                   `json:"itemKeys"`
 	PostFields                 PostFields                 `json:"postFields"`
+	Encoding                   string                     `json:"encoding"`
 }
 
 type CategorySpecificAttributes struct {

--- a/htmlParsers/scrapePlainHtml.go
+++ b/htmlParsers/scrapePlainHtml.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"regexp"
 	"time"
+	"strings"
 
 	"github.com/gocolly/colly"
 )
@@ -21,6 +22,15 @@ func ScrapePlainHtml(config configuration.Config) []variables.Item {
 	// c.OnHTML("body", func(h *colly.HTMLElement) {
 	// 	fmt.Println(h)
 	// })
+
+	encodeQuery := func(input string) string {
+		switch config.Search.Encoding {
+		case "hyphen":
+			return strings.ReplaceAll(input, " ", "-")
+		default:
+			return url.QueryEscape(input)
+		}
+	}
 
 	c.OnHTML(itemKeys.Root, func(h *colly.HTMLElement) {
 		item := variables.Item{
@@ -100,10 +110,10 @@ func ScrapePlainHtml(config configuration.Config) []variables.Item {
 		for key, value := range config.Search.PostFields.Generic {
 			formData[key] = value
 		}
-		formData[config.Search.PostFields.Input] = variables.CURRENT_INPUT
+		formData[config.Search.PostFields.Input] = encodeQuery(variables.CURRENT_INPUT)
 		c.Post(config.Search.Url, formData)
 	} else {
-		formattedInput := config.Search.Url + url.QueryEscape(variables.CURRENT_INPUT)
+		formattedInput := config.Search.Url + encodeQuery(variables.CURRENT_INPUT)
 		// some websites support multiple categories, to avoid irrelevant results, only search in relevant categories
 		if config.Search.CategorySpecificAttributes.Name != "" {
 			for category, value := range config.Search.CategorySpecificAttributes.Values {


### PR DESCRIPTION
Some websites expect spaces in search URLs to be encoded as hyphens, rather than the more standard `%20`, so they don't return anything for multi-word searches, because they're expecting `/search/movie-title`, not `/search/movie%20title`. This PR adds an `"encoding"` option to website configs, which currently accepts `"hyphen"` or nothing, and does a quick ReplaceAll in those cases. As an example, it includes updated configs for three websites that I noticed this issue on.